### PR TITLE
posts from old H2O blog for new H2O blog

### DIFF
--- a/app/_posts/2018-10-12-casebooks-on-amazon-created-on-h2o.md
+++ b/app/_posts/2018-10-12-casebooks-on-amazon-created-on-h2o.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: "Casebooks on Amazon, created on H2O"
+author: brett-johnson
+date: 2018-10-12 16:00:43+00:00
+
+---
+
+Several instructors have utilized H2O’s export feature to export their casebooks out of H2O and after some clean-up, load them into a print-on-demand service (such as Amazon CreateSpace) and offer the text as a print book at a fraction of the cost of a traditional casebook. Here, a selection of casebooks created on H2O, now offered as a print text through Amazon:
+
+[Corporations](https://www.amazon.com/Corporations-Holger-Spamann/dp/1725809133/ref=sr_1_3?ie=UTF8&qid=1539384906&sr=8-3&keywords=corporations+holger+spamann), Holger Spamann
+
+[Contracts](https://www.amazon.com/dp/1979844712), Charles Fried
+
+[Torts!](https://www.amazon.com/dp/1978447132), Jonathan Zittrain
+
+[Contracts!](https://www.amazon.com/Contracts-Promises-Commerce-J-Ellis/dp/1722481528), Griswold Reading Groups
+
+Create your own account on H2O, then begin making your own casebook or clone and begin remixing an existing casebook!

--- a/app/_posts/2018-10-25-OER-Materials-Beneficial-to-Students-Per-New-Study.md
+++ b/app/_posts/2018-10-25-OER-Materials-Beneficial-to-Students-Per-New-Study.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "OER Materials Beneficial to Students, Per New Study"
+author: brett-johnson
+date: 2018-10-25 16:00:43+00:00
+
+---
+
+According to a newly released study by Achieving the Dream, implementation of Open Education Resources (OER) found “significant benefits to instruction and student learning experiences” in addition to the cost savings passed on to the students.Over 60% of students reported that their overall quality of their learning experience was higher in comparison to a typical, non-OER course.
+
+>“The study indicates that, based on two years of implementation across scores of colleges, OER can be an important tool in helping more students—and particularly low-income and underrepresented students—afford college, engage actively in their learning, persist in their studies, and ultimately complete,” said Dr. Karen A. Stout, Achieving the Dream president and CEO. “Data show that even using the most conservative estimates, cost savings are significant and that OER content plays a role in helping strengthen instruction and learning across not just a few courses but entire degree pathways.
+
+-[source](https://www.achievingthedream.org/news/17519/new-study-finds-oer-courses-and-degrees-improve-student-retention-and-completion-faculty-engagement-and-result-in-cost-savings-for-students)
+
+Though creating OER materials can take more time than using traditional, pre-made materials, students appeared to be more engaged with the learning experience and found the materials more relevant and interesting.
+
+H2O is a leader in the field of creating OER for law materials – be they full casebooks, supplemental materials, or simply a place to collect resources for your class. Create an account today at [opencasebook.org](https://opencasebook.org)!

--- a/app/_posts/2018-11-07-Entire-Caselaw-Access-Project-CAP-Database-Accessible-via-H2O.md
+++ b/app/_posts/2018-11-07-Entire-Caselaw-Access-Project-CAP-Database-Accessible-via-H2O.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "Entire Caselaw Access Project (CAP) Database, Accessible via H2O!"
+author: brett-johnson
+date: 2018-11-07 16:00:43+00:00
+
+---
+
+Now that the [Caselaw Access Project](https://lil.law.harvard.edu/blog/2018/10/29/caselaw-access-project-cap-launches-api-and-bulk-data-service/) has gone public, it’s worth pointing out that the OER materials/free casebook creator H2O is fully integrated with the CAP database: the text of any of CAP’s 6.4 million cases can be used in H2O.
+
+![Image of Caselaw Access Project U.S. Coverage Map](http://blogs.harvard.edu/h2oharvard/files/2018/11/DqsWTb2W4AEyk-.jpg)
+
+To use a case from CAP in H2O, when viewing a draft casebook you’re working on, click Add Resource, then Add Case. Type in the case’s citation – for example, “410 U.S. 113” – then click Search. Select the case and it will automatically be added in full to your casebook. You can then make annotations to this case, as well as move it to the location you’re wanting it in your casebook.
+
+Find out more about the CAP project at case.law, and create your own H2O account at [opencasebook.org](https://opencasebook.org)!

--- a/app/_posts/2019-01-15-H2Os-Big-Questions-Updated.md
+++ b/app/_posts/2019-01-15-H2Os-Big-Questions-Updated.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: "H2O’s Big Questions, Updated"
+author: brett-johnson
+date: 2019-01-15 16:00:43+00:00
+
+---
+
+As 2019 kicks into gear, many components have fallen into place that make 2019 look be H2O’s best year yet. From the redesign and CAP case law database integration to improved (and new! See next post on Collaborators) functionality and usability, H2O is poised to make a splash in the world of OER and legal education. Below we field some of the big questions that get thrown our way. Take a look, then check out H2O open casebook yourself!
+
+**Have Harvard professors used H2O?**
+
+Over 20 professors at Harvard Law School have used H2O for their courses since 2010, along with dozens of instructors at other universities. HLS faculty who have used H2O for their courses include Profs. Jonathan Zittrain (Torts), Chris Bavitz (Music & Digital Media), Jeannie Suk-Gersen (Criminal Law), Holger Spamann (Corporate Law), Professor Terry Fisher and the affiliate instructors in his CopyrightX course (Copyright), Howell Jackson (Regulation of Financial Institutions and others), and Professor Jacob Gersen (Legislation & Regulation).
+
+**I want to use H2O to teach my class. Can you help get me going?**
+
+H2O is built to be self-service, with our user guide ( https://about.opencasebook.org /) addressing most user questions, but we love to hear from professors interested in using H2O, whether to develop a new casebook from scratch or to adapt existing casebooks or syllabi. Reach out to us at info[at opencasebook.org!
+
+**What is an H2O casebook?**
+
+A traditional casebook is a legal textbook for a particular area of study, containing excerpts from cases in which the law of that area was applied. An H2O casebook is a re-mixable, user-created collection of content – often including excerpted cases – that is easily shared and remixed, and is ideal for use as an online course syllabus. An H2O casebook can also be exported to a Word doc, then sent to a print-on-demand service if the professor wishes to create a hard copy of it to distribute or sell.
+Professors can build an H2O casebook from scratch, or copy another professor’s casebook and modify it according to their objectives. A casebook can consist of any combination of edited cases, texts, cases, and links, wit professors deciding what items to include and in what order. They can also add a description/headnote for their casebook, casebook sections, and items.
+
+**How do I create a casebook?**
+
+Anyone can create a casebook by first creating an account. To do so, click “Sign up for free” in the upper right while at the H2O homepage. Once logged-in, click the “Create casebook” button, where you can select “Make a New Casebook” or, if you want to adapt an existing casebook, “Search Casebooks.” For more on creating casebooks and adding content, view the entry on creating casebooks in our user guide.
+
+**How do I get a case that is not in the database yet?**
+
+The H2O caselaw database, which already included 2200+ cases, is now integrated with the Caselaw Access Project (CAP) database , which contains the full corpus of U.S. caselaw.
+When searching for a case via the Add Resource button, searching by the parties’ names will search just the cases in the H2O database. If you wish to add a case from CAP, type in the case’s citation – for example, “410 U.S. 113” – then click Search. Select the case that appears, and it will automatically be added in full to your casebook. This will also add the case to H2O’s own database.
+
+**Can I share copyrighted material in my H2O playlist?**
+
+Yes, though it must be linked to on the web, rather than uploaded directly to H2O. As content in H2O is shared under a Creative Commons 3.0 license, copyrighted material that is not compatible with that must be either directly linked to, or, when excerpted, linked to behind a firewall with access available only to those who have permission to view it.
+
+**How do I export/print a casebook or item?**
+
+To print an entire casebook, or a single item (such as an edited case or text), click the export button in the upper-right side of the screen while viewing what you wish to export or print. If there are annotations on the item, a dialogue box will appear asking whether or not you wish to include annotations. After selecting one of these, your browser will download a Word document that includes what you wished exported, which can then be printed.
+
+**What are you working on now?**
+
+We’re working to improve the speed and responsiveness of annotations, as well as exploring easy ways for instructors to import their syllabus or course outline directly to an H2O casebook.
+We’ve also released a “Collaborators” feature that allow admins to designate more than one user the ability to edit a single casebook. Shoot us an email at info[at opencasebook.org to request this for your team!
+
+**Who has supported H2O?**
+
+H2O is a project of the Library Innovation Lab at the Harvard Law School, and has received generous support over the years from from the Harvard Library Lab, the Harvard Initiative for Learning and Teaching, Fastcase, and the Berkman-Klein Center for Internet and Society.

--- a/app/_posts/2019-01-15-NEW-Add-Collaborators-to-your-Casebook.md
+++ b/app/_posts/2019-01-15-NEW-Add-Collaborators-to-your-Casebook.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: "NEW: Add Collaborators to your Casebook"
+author: brett-johnson
+date: 2019-01-15 16:00:43+00:00
+
+---
+
+H2O has been around for a while, consistently worked on to make it simpler and more useful for instructors and students. One feature that’s been requested for some time, though, is now finally public: “collaborators” – the ability for multiple users to make changes to the same casebook-syllabus without having to share login info.
+
+WIth collaborators, professors can now request access for specific casebooks be given to their admin staff or teaching/research assistants. Once given access, these collaborators can make changes, update, and make public (‘publish’) these changes on the H2O platform.
+
+To add a user as a collaborator to one of your casebooks, simply shoot us an email – info(@ opencasebook.org – with the email of the user you’d like to add, and the ID # of the casebook you’d like them added to, which can be found in the URL when viewing it.
+
+While we plan to make this self-service in the future, we’re excited about this new feature as it is and how H2O’s growing use will help accelerate the use of OER in legal education.
+
+Questions? Email us at the above!
+-The H2O team

--- a/app/_posts/2019-02-15-H2O-annotations-Reborn.md
+++ b/app/_posts/2019-02-15-H2O-annotations-Reborn.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: "H2O Annotations, Reborn!"
+author: brett-johnson
+date: 2019-02-15 16:00:43+00:00
+
+---
+
+We’ve had some recent, exciting developments in the world of H2O, building on work already done that allows more than one user to edit casebooks as well as the integration with the [Caselaw Access Project](https://lil.law.harvard.edu/blog/2018/10/29/caselaw-access-project-cap-launches-api-and-bulk-data-service/).
+
+After the recent H2O redesign, the navigation and readability of the site’s content both improved, but one thing that remained at the same pace was the time it took to apply an annotation – elision, highlight, etc – to the text.
+
+After some deep work done by the H2O dev team – this has improved remarkably. As opposed to annotations taking several seconds to apply, including a refresh of the page, annotations now immediately apply. See below:
+
+![looping animated image of the elide annotation in H2O](http://blogs.harvard.edu/h2oharvard/files/2019/02/LPF7gCzHLO.gif)
+
+Massive thanks to Greg and Casey for their hard work on this feature!


### PR DESCRIPTION
7 blog posts that were made on the old H2O blog, to be moved to the new H2O blog.