### PR TITLE
Updates - Quick Basics

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -16,8 +16,8 @@ sharing-image: images/h2o-logo.svg
         <li ><a href="#welcome">Welcome to H2O</a></li>
         <li>
             <ul class="toc-level-2">
-            <li><a href="#why">Why?</a></li>
             <li><a href="#what">What?</a></li>
+            <li><a href="#why">Why?</a></li>
             <li><a href="#how">How?</a></li>
         </ul>
         </li>
@@ -48,17 +48,20 @@ sharing-image: images/h2o-logo.svg
 <main id="main" class="docs-text">
 
     <h2 id="welcome">Welcome to H2O!</h2>
+    
+    <h3 id="what">What is H2O?</h3>
+    <p>H2O is a website that helps faculty authors make casebooks that are free, simple to modify, and easy to access and print. H2O is offered by the Harvard Law School Library, through its <a href="https://lil.law.harvard.edu" target="_blank">Library Innovation Lab</a>.</p>
 
     <h3 id="why">Why did we build H2O?</h3>
     <p>The casebook - annotated collections of court cases - has been a cornerstone of legal education for over 150 years. But casebooks today are heavy, expensive and way too difficult to use.</p>
     <p>We believe casebooks can be better for authors and students. Authors should be able to easily create or customize their own casebooks online. And students should be able read the casebooks online or in print for little or no cost.</p>
 
-    <h3 id="what">What is H2O?</h3>
-    <p>H2O is a website that helps faculty authors make casebooks that are free, simple to modify, and easy to access and print. H2O is offered by the Harvard Law School Library, through its <a href="https://lil.law.harvard.edu" target="_blank">Library Innovation Lab</a>.</p>
-
     <h3 id="how">How does H2O work?</h3>
-    <p>H2O gives authors access to the entire database of U.S. court decisions made available through the <a href="https://case.law" target="_blank">CaseLaw Access Project</a>, another initiative of the Library Innovation Lab. Authors can pull any of those cases into their casebooks, together with their own texts and links to external sources on the web. These casebooks, in turn, are free to access and can be copied, shared and adapted under a <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">CC BY-NC-SA 3.0 license</a>. In addition, H2O's software is open source and available on <a href="https://github.com/harvard-lil/h2o" target="_blank">Github</a>. </p>
+    <p>You can use H2O to create casebooks, reading lists, course outlines, syllabi, and more. H2O gives authors access to the entire database of U.S. court decisions made available through the <a href="https://case.law" target="_blank">CaseLaw Access Project</a>, another initiative of the Library Innovation Lab. Authors can pull any of those cases into their casebooks, together with their own texts and links to external sources on the web. These casebooks, in turn, are free to access and can be copied, shared and adapted under a <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" target="_blank">CC BY-NC-SA 3.0 license</a>. In addition, H2O's software is open source and available on <a href="https://github.com/harvard-lil/h2o" target="_blank">Github</a>. </p>
 
+    <h3>How can I use H2O?</h3>
+    <p>You can use H2O to create casebooks, reading lists, course outlines, syllabi, and more. 
+    
     <h2 id="making-casebooks">Making Casebooks</h2>
     <h3 id="accounts">Accounts</h3>
     <p>You'll need to register for an account to make casebooks. You don't need an account to read casebooks.</p>
@@ -106,7 +109,7 @@ sharing-image: images/h2o-logo.svg
     <p>To print your casebook, click the Export button. H2O will download a Word file containing the entire contents of your casebook. Open the file in Word to make any layout, formatting or other changes before printing.</p>
 
     <h3 id="archiving">Archiving</h3>
-    <p>To archive a draft casebook and remove it from your dashboard, go to your casebook's "Settings" tab and click "Archive." The casebook no longer will be visible on your dashboard but you'll still be able to access it by clicking the "[View Archived Casebooks]" link on the upper right-hand side of your dashboard. If necessary, you can "Unarchive" the casebook from there.</p>
+    <p>To archive a draft casebook and remove it from your dashboard, go to your casebook's "Settings" tab and click "Archive." The casebook no longer will be visible on your dashboard but you'll still be able to access it by clicking the "View Archived Casebooks" link on the upper right-hand side of your dashboard. If necessary, you can "Unarchive" the casebook from there.</p>
     <figure>
         <img src="{{ site.baseurl }}/assets/images/archive-casebook.png" alt="A screenshot of a casebook's settings tab showing the archive button.">
     </figure>
@@ -116,7 +119,7 @@ sharing-image: images/h2o-logo.svg
     <p>You don't need an account to read casebooks, but you'll need one if you want to clone or export casebooks. If you want an account, <a href="https://opencasebook.org/accounts/new/">sign up here for free</a>.</p>
     <h3 id="reading-casebooks">Reading Casebooks</h3>
     <p>To find a particular casebook, either get the link from your professor or <a href="https://opencasebook.org/search" target="_blank">search H2O</a> for your professor's name or the title of the casebook.</p>
-    <p>Here's an example of a casebook, for contracts: <a href="https://opencasebook.org/casebooks/25965-contracts/" target="_blank">https://opencasebook.org/casebooks/25965-contracts/</a>. Navigate through it by clicking on sections or individual cases or other resources.</p>
+    <p>Here's an example of a casebook, for <a href="https://opencasebook.org/casebooks/25965-contracts/">Contracts</a>. Navigate through it by clicking on sections or individual cases or other resources.</p>
     <h3 id="students-exporting-printing">Export and Print</h3>
     <p>You can print H2O casebooks or portions of casebooks. Use the Export button to download a Word file with the contents of the casebook. Open the file in Word, make any formatting changes you like, then print it from Word.</p>
 


### PR DESCRIPTION
Updates:
- Reorder questions / navigation to place "What is H2O?" first.
- Highlight use cases, included in "How does H2O work?" to add "You can use H2O to create casebooks, reading lists, course outlines, syllabi, and more."
- Link and capitalize word "contracts", swap out full url: “Here's an example of a casebook, for contracts: https://opencasebook.org/casebooks/25965-contracts/.”
- Remove brackets: "[View Archived Casebooks]" link on the upper right-hand side of your dashboard."