### PR TITLE
Add slack notification to deploy

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -80,3 +80,22 @@ jobs:
         env:
           CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+              text: "H2O Static site deployed successfully!",
+              blocks:
+                - type: section
+                  fields:
+                    - type: mrkdwn
+                      text: "*Branch:*\n`${{ github.ref }}`"
+                    - type: mrkdwn
+                      text: "*Commit:*\n`${{ github.sha }}`"
+                - type: section
+                  text:
+                    type: mrkdwn
+                    text: "View the site: <https://about.opencasebook.org|https://about.opencasebook.org>"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -90,12 +90,6 @@ jobs:
               text: "H2O Static site deployed successfully!",
               blocks:
                 - type: section
-                  fields:
-                    - type: mrkdwn
-                      text: "*Branch:*\n`${{ github.ref }}`"
-                    - type: mrkdwn
-                      text: "*Commit:*\n`${{ github.sha }}`"
-                - type: section
                   text:
                     type: mrkdwn
                     text: "View the site: <https://about.opencasebook.org|https://about.opencasebook.org>"


### PR DESCRIPTION
Added a step to notify the #lil-bots Slack channel after a deploy is completed. Includes a link to the live site.