### PR TITLE
uses different action to invalidate cache

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -70,10 +70,9 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
 
       - name: Invalidate CloudFront
-        uses: chetan/invalidate-cloudfront-action@v2
-        env:
-          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
-          PATHS: '/*'
+        uses: koki-develop/cloudfront-invalidate-action@v1.0.4
+        with:
+          id: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
 
       - name: Purge Cloudflare cache
         uses: jakejarvis/cloudflare-purge-action@master


### PR DESCRIPTION
This PR uses a different Github action for the Cloudfront distribution invalidation. The new action will wait for the invalidation to confirm it has completed before finishing the action step. This will prevent the Cloudflare cache purge step from running early.

The new action:
https://github.com/marketplace/actions/cloudfront-invalidate-action