### PR TITLE
Use the org-scoped Cloudflare Pages token

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -69,7 +69,7 @@ jobs:
           branch: develop
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
 
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
Map the organization secret `CLOUDFLARE_PAGES_TOKEN` to Wrangler's required `CLOUDFLARE_API_TOKEN` environment variable, rather than using a repo secret.